### PR TITLE
Dev

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -61,6 +61,7 @@
         </StackPanel>
         <Button Name="LaunchButton" Content="{Binding Localization[LaunchButton]}" Margin="0,20,0,10"
                 Classes="LaunchButton"
+                Click="LaunchButton_Click"
                 />
         <TextBlock Text="{Binding Localization[SelectResolution]}" Foreground="White" Margin="0,10,0,5"/>
         <ComboBox Name="ResolutionComboBox" HorizontalAlignment="Stretch"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -126,7 +126,7 @@ public partial class MainWindow : Window
             "DirectX 11" => useAvx ? "AnomalyDX11AVX.exe" : "AnomalyDX11.exe",
             _ => "AnomalyDX9.exe" // Default to DirectX 9 if no renderer is selected
         };
-        string exePath = Path.Combine(AppContext.BaseDirectory, "bin", exeName);
+        string exePath = Path.Combine(gameDirectory, "bin", exeName);
         var args = new List<string>();
         string resolution = ResolutionComboBox.SelectedItem?.ToString();
         if (!string.IsNullOrWhiteSpace(resolution))

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -112,7 +112,7 @@ public partial class MainWindow : Window
     
     private async void LaunchButton_Click(object sender, RoutedEventArgs e)
     {
-        string launcherPath = Path.GetDirectoryName(Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location);
+        string launcherPath = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
         string gameDirectory = launcherPath;
         string renderer = RenderComboBox.SelectedItem?.ToString();
         bool useAvx = AvxCheckBox.IsChecked == true;

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -112,7 +112,7 @@ public partial class MainWindow : Window
     
     private async void LaunchButton_Click(object sender, RoutedEventArgs e)
     {
-        string launcherPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string launcherPath = Path.GetDirectoryName(Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location);
         string gameDirectory = launcherPath;
         string renderer = RenderComboBox.SelectedItem?.ToString();
         bool useAvx = AvxCheckBox.IsChecked == true;

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -112,10 +112,14 @@ public partial class MainWindow : Window
     
     private async void LaunchButton_Click(object sender, RoutedEventArgs e)
     {
+        string launcherPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string gameDirectory = launcherPath;
         string renderer = RenderComboBox.SelectedItem?.ToString();
         bool useAvx = AvxCheckBox.IsChecked == true;
         string exeName = renderer switch
         {
+
+
             "DirectX 8" => useAvx ? "AnomalyDX8AVX.exe" : "AnomalyDX8.exe",
             "DirectX 9" => useAvx ? "AnomalyDX9AVX.exe" : "AnomalyDX9.exe",
             "DirectX 10" => useAvx ? "AnomalyDX10AVX.exe" : "AnomalyDX10.exe",
@@ -143,7 +147,7 @@ public partial class MainWindow : Window
             {
                 FileName = exePath,
                 Arguments = string.Join(" ", args),
-                WorkingDirectory = Path.Combine(AppContext.BaseDirectory, "bin")
+                WorkingDirectory = gameDirectory
             };
             Process.Start(stalker);
         }

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -10,6 +11,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform;
+using MsBox.Avalonia;
 
 namespace AvaLauncherStalker;
 
@@ -106,6 +108,58 @@ public partial class MainWindow : Window
     private void SetEnglishLanguage(object sender, RoutedEventArgs e)
     {
         Localization.SetLanguage("en-US");
+    }
+    
+    private async void LaunchButton_Click(object sender, RoutedEventArgs e)
+    {
+        string renderer = RenderComboBox.SelectedItem?.ToString();
+        bool useAvx = AvxCheckBox.IsChecked == true;
+        string exeName = renderer switch
+        {
+            "DirectX 8" => useAvx ? "AnomalyDX8AVX.exe" : "AnomalyDX8.exe",
+            "DirectX 9" => useAvx ? "AnomalyDX9AVX.exe" : "AnomalyDX9.exe",
+            "DirectX 10" => useAvx ? "AnomalyDX10AVX.exe" : "AnomalyDX10.exe",
+            "DirectX 11" => useAvx ? "AnomalyDX11AVX.exe" : "AnomalyDX11.exe",
+            _ => "AnomalyDX9.exe" // Default to DirectX 9 if no renderer is selected
+        };
+        string exePath = Path.Combine(AppContext.BaseDirectory, "bin", exeName);
+        var args = new List<string>();
+        string resolution = ResolutionComboBox.SelectedItem?.ToString();
+        if (!string.IsNullOrWhiteSpace(resolution))
+            args.Add($"-res {resolution}");
+
+        string shadow = ShadowMapComboBox.SelectedItem?.ToString();
+        if (!string.IsNullOrWhiteSpace(shadow))
+            args.Add($"-shadowmap {shadow}");
+        
+        if (DevCheckBox.IsChecked == true) args.Add("-dev");
+        if (ClearCacheCheckBox.IsChecked == true) args.Add("-nocache");
+        if (ReloadSoundsCheckBox.IsChecked == true) args.Add("-reload_sounds");
+        if (DefaultUserLtxCheckBox.IsChecked == true) args.Add("-fsltx user.ltx");
+        
+        try
+        {
+            var stalker = new ProcessStartInfo
+            {
+                FileName = exePath,
+                Arguments = string.Join(" ", args),
+                WorkingDirectory = Path.Combine(AppContext.BaseDirectory, "bin")
+            };
+            Process.Start(stalker);
+        }
+        catch (Exception ex)
+        {
+            var  messageBox = MessageBoxManager
+                .GetMessageBoxStandard("Ошибка", $"Произошла ошибка при запуске игры:\n{ex.Message}");
+            var res = await messageBox.ShowAsync();
+
+        }
+
+
+
+
+            
+
     }
 
 


### PR DESCRIPTION
# 🛠️ Ветка `dev`

> _Наконец-то я придал лаунчеру хоть какой-то смысл._

---

## ✨ Что сделано:

- Обновлена архитектура лаунчера — теперь это не просто кнопка «Запуск».
- Обновлены настройки рендера, карт теней.
- Реализована предзагрузка звуков, выбор ращрешения и восстановление `user.ltx` до дефолтного состояния.
- Возможность запуска соответствующего `.exe`-файла в зависимости от выбранного рендера и поддержки AVX.

